### PR TITLE
fix: REGIONS variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const CleverTap = require('clevertap');
  SINGAPORE: 'sg1',
  US: 'us1'
 */
-const clevertap = CleverTap.init(YOUR_CLEVERTAP_ACCOUNT_ID, YOUR_CLEVERTAP_ACCOUNT_PASSCODE, CleverTap.CLEVERTAP_REGIONS.EUROPE);
+const clevertap = CleverTap.init(YOUR_CLEVERTAP_ACCOUNT_ID, YOUR_CLEVERTAP_ACCOUNT_PASSCODE, CleverTap.REGIONS.EUROPE);
 
 // the library supports both callbacks and Promises
 


### PR DESCRIPTION
`REGIONS` is exported and not `CLEVERTAP_REGIONS`
Reference: https://github.com/CleverTap/clevertap-node/blob/abf14e6535844f2e7211615c14914eb4556b0db1/lib/clevertap.js#L573